### PR TITLE
Add warnings for Gandling, Alexei Barov and pull timer for Pyroguard Emberseer

### DIFF
--- a/DBM-Party-Classic/Scholomance/DarkmasterGandling.lua
+++ b/DBM-Party-Classic/Scholomance/DarkmasterGandling.lua
@@ -5,3 +5,19 @@ mod:SetRevision("@file-date-integer@")
 mod:SetCreatureID(1853)
 
 mod:RegisterCombat("combat")
+
+mod:RegisterEventsInCombat(
+	"SPELL_CAST_SUCCESS 17950"
+)
+
+local warningShadowPortal		= mod:NewSpellAnnounce(17950, 2) -- Target seems unreliable
+
+do
+	local ShadowPortal = DBM:GetSpellInfo(17950)
+	function mod:SPELL_CAST_SUCCESS(args)
+		--if args.spellId == 17950 then
+		if args.spellName == ShadowPortal then
+			warningShadowPortal:Show()
+		end
+	end
+end

--- a/DBM-Party-Classic/Scholomance/LordAlexeiBarov.lua
+++ b/DBM-Party-Classic/Scholomance/LordAlexeiBarov.lua
@@ -5,3 +5,19 @@ mod:SetRevision("@file-date-integer@")
 mod:SetCreatureID(10504)
 
 mod:RegisterCombat("combat")
+
+mod:RegisterEventsInCombat(
+	"SPELL_AURA_APPLIED 17820"
+)
+
+local warningVeilofShadow			= mod:NewTargetNoFilterAnnounce(17820, 2, nil, "RemoveCurse")
+
+do
+	local VeilofShadow = DBM:GetSpellInfo(17820)
+	function mod:SPELL_AURA_APPLIED(args)
+		--if args.spellId == 17820 then
+		if args.spellName == VeilofShadow then
+			warningVeilofShadow:CombinedShow(0.5, args.destName)
+		end
+	end
+end

--- a/DBM-Party-Classic/UpperBlackrockSpire/PyroguardEmberseer.lua
+++ b/DBM-Party-Classic/UpperBlackrockSpire/PyroguardEmberseer.lua
@@ -5,3 +5,15 @@ mod:SetRevision("@file-date-integer@")
 mod:SetCreatureID(9816)
 
 mod:RegisterCombat("combat")
+
+mod:RegisterEvents(
+	"CHAT_MSG_MONSTER_EMOTE"
+)
+
+local timerCombatStart	= mod:NewCombatTimer(64)
+
+function mod:CHAT_MSG_MONSTER_EMOTE(msg)
+	if msg == L.Pull then
+		timerCombatStart:Start()
+	end
+end

--- a/DBM-Party-Classic/localization.en.lua
+++ b/DBM-Party-Classic/localization.en.lua
@@ -283,6 +283,9 @@ L = DBM:GetModLocalization("PyroguardEmberseer")
 L:SetGeneralLocalization{
 	name 		= "Pyroguard Emberseer"
 }
+L:SetMiscLocalization{
+	Pull		= "%s begins to regain its strength!"
+}
 -----------------------------
 --  Solakar Flamewreath  --
 -----------------------------


### PR DESCRIPTION
This is by no means a complete set of ability warnings for these bosses, but a small addition :)

Gandling's [Shadow Portal](https://classic.wowhead.com/spell=17950) gave me quite the headache to test, because it's a targeted spell, but it's not always the player the spell lands on that gets teleported away.

Curse warning for Alexei Barov's [Veil of Shadow](https://classic.wowhead.com/spell=17820/veil-of-shadow). It's probably the spell I found most troublesome in level 60 dungeons which is why I felt like adding this one specifically ^^

The pull timer for Pyroguard Emberseer is just a convenience, since people are just standing around waiting for him :)