### PR TITLE
More precise Chromaggus emote

### DIFF
--- a/DBM-BWL/localization.en.lua
+++ b/DBM-BWL/localization.en.lua
@@ -95,7 +95,7 @@ L:SetOptionLocalization{
 L:SetMiscLocalization{
 	Breath1		= "First Breath",
 	Breath2		= "Second Breath",
-	VulnEmote	= "flinches as its skin shimmers."
+	VulnEmote	= "%s flinches as its skin shimmers."
 }
 
 ----------------


### PR DESCRIPTION
Make the localization more precise.
Verified working in raid tonight. (disabled sync warning to just very locally)