### PR TITLE
Fix localization of Emeriss

### DIFF
--- a/DBM-Azeroth/localization.de.lua
+++ b/DBM-Azeroth/localization.de.lua
@@ -60,7 +60,7 @@ L:SetMiscLocalization({
 L = DBM:GetModLocalization("Emeriss")
 
 L:SetGeneralLocalization{
-	name = "Smariss"
+	name = "Emeriss"
 }
 
 L:SetMiscLocalization({


### PR DESCRIPTION
In 1.13-Classic, the german translation for Emeriss is still Emeriss. The change to Smariss was done in a later expansion.

Proof:
[German wowhead classic page of Emeriss](https://de.classic.wowhead.com/npc=14889/emeriss)

Screenshot of Emeriss with a german client
![image](https://user-images.githubusercontent.com/19301362/81500394-45335180-92d2-11ea-9418-2c872a800a1d.png)
