### PR TITLE
Update Onyxia.lua

### DIFF
--- a/DBM-Onyxia/Onyxia.lua
+++ b/DBM-Onyxia/Onyxia.lua
@@ -93,6 +93,10 @@ do
 	function mod:FireballTarget(targetname, uId)
 		if not targetname then return end
 		warnFireball:Show(targetname)
+		if GetRaidTargetIndex(targetname) ~= 8 then
+			-- If another DBM/BigWigs client has not yet put a skull on said player, attempt to do so.
+			SetRaidTarget(targetname, 8) -- Automatically ignored if the user does not have raid assist.
+		end
 		if targetname == UnitName("player") then
 			yellFireball:Yell()
 		end


### PR DESCRIPTION
Changes in response to a comment thread on reddit.com/r/classicwow: https://www.reddit.com/r/classicwow/comments/gz2krv/whats_up_with_dbm_addon_updating_every_day/ftet5ee/

DBM has had the 'skull placed on users who are fireballed' feature since 2005. This feature does not currently exist in classic wow's version of DBM. This change should amend that.

To cut down on excessive API calls, the user's raid permissions can be cached locally. That way `GetRaidTargetIndex` and `SetRaidTarget` is only called if the locally stored `boolean` value representing if the user has raid assist is `true`.