### PR TITLE
Should MCTrash not come before Lucifron

### DIFF
--- a/DBM-MC/DBM-MC.toc
+++ b/DBM-MC/DBM-MC.toc
@@ -31,6 +31,7 @@ localization.br.lua
 localization.kr.lua
 localization.tw.lua
 localization.cn.lua
+MCTrash.lua
 Lucifron.lua
 Magmadar.lua
 Gehennas.lua
@@ -41,4 +42,3 @@ Sulfuron.lua
 Golemagg.lua
 Majordomo.lua
 Ragnaros.lua
-MCTrash.lua


### PR DESCRIPTION
When its called in Lucifron for getmod, it actually exists?

Should fix #253 