### PR TITLE
Update localization.tw.lua

### DIFF
--- a/DBM-ZG/localization.tw.lua
+++ b/DBM-ZG/localization.tw.lua
@@ -25,7 +25,7 @@ L:SetGeneralLocalization{
 L = DBM:GetModLocalization("Marli")
 
 L:SetGeneralLocalization{
-	name = "高階祭司瑪爾裏"
+	name = "高階祭司瑪俐"
 }
 
 -------------------
@@ -65,7 +65,7 @@ L:SetMiscLocalization({
 L = DBM:GetModLocalization("Arlokk")
 
 L:SetGeneralLocalization{
-	name = "高階祭司娅爾羅"
+	name = "高階祭司阿洛克"
 }
 
 -------------------


### PR DESCRIPTION
Looks like the name for Mar'li and Arlokk was different on warcraft logs. Does warcraft logs grab the boss name directly from the combat log, or is it just taking the name that is being used on DBM?
Source:
https://classic.warcraftlogs.com/reports/K9TJNGwWA6CvrbQH#fight=9