### PR TITLE
Adjust Ramstein add timer after more testing

### DIFF
--- a/DBM-Party-Classic/Stratholme/RamsteintheGorger.lua
+++ b/DBM-Party-Classic/Stratholme/RamsteintheGorger.lua
@@ -27,7 +27,7 @@ end
 function mod:OnCombatEnd(wipe, isSecondRun)
 	if not wipe and not isSecondRun and self.Options.TimerGuards then
 		-- Custom bar that's bound to core so timer doesn't stop when mod stops its own timers
-		DBM.Bars:CreateBar(92, self.localization.timers.TimerGuards, 136187, nil, nil, nil, nil, self.Options.TimerGuardsTColor, nil, nil, nil, self.Options.TimerGuardsCVoice)
+		DBM.Bars:CreateBar(91, self.localization.timers.TimerGuards, 136187, nil, nil, nil, nil, self.Options.TimerGuardsTColor, nil, nil, nil, self.Options.TimerGuardsCVoice)
 	end
 end
 


### PR DESCRIPTION
Tested new code and timer was just a hair too long. This is the 5th time I run this boss just to test the timer. 😅

Two most recent runs before this the time was 92.65 and 92.03, but this time it was 91.45.

It's better if the timer is a hair too short than too long.