### PR TITLE
Increase Ragnaros range check

### DIFF
--- a/DBM-MC/Ragnaros.lua
+++ b/DBM-MC/Ragnaros.lua
@@ -33,7 +33,7 @@ local timerEmerge		= mod:NewTimer(90, "TimerEmerge", "Interface\\AddOns\\DBM-Cor
 --local timerCombatStart	= mod:NewCombatTimer(73)
 local timerCombatStart	= mod:NewTimer(73, "timerCombatStart", "132349", nil, nil, nil, nil, nil, 1, 3)
 
-mod:AddRangeFrameOption("10", nil, "-Melee")
+mod:AddRangeFrameOption("18", nil, "-Melee")
 
 mod.vb.addLeft = 0
 mod.vb.ragnarosEmerged = true
@@ -47,7 +47,7 @@ function mod:OnCombatStart(delay)
 	timerWrathRag:Start(26.7-delay)
 	timerSubmerge:Start(180-delay)
 	if self.Options.RangeFrame then
-		DBM.RangeCheck:Show(10)
+		DBM.RangeCheck:Show(18)
 	end
 end
 


### PR DESCRIPTION
### Short description
Ragnaros range check has unfortunately been too short for all of WoW Classic. This should make it a little bit better.

### Long description
I played with some new player last week and a lot of them complained over having no other player inside their 10 yard range check, but were still knocked all over the place. After asking around, it seems that very few people understand what the _actual_ range should be. This pull request of my research.

Back in the day Blizzard did some really wonky stuff to get the raid to behave like they wanted. For example, we have the now somewhat infamous [Core Rat](https://classic.wowhead.com/npc=13338/core-rat) - an NPC that's just there to create some triggers.

At first, I found it weird that the actual spell used for the knockback effect was not shown in the combat log, or on **Warcraft Logs**. **[But then I found it!](https://classic.warcraftlogs.com/reports/nvWZ46JGMArbfxTN/#fight=last&type=healing&source=9&view=events)** So, [Intense Heat](https://classic.wowhead.com/spell=21155/intense-heat) is the spell, and it has a 20 yard knockback and causes 2000 damage. `Cast time is hidden`. It won't show up in the combat log.

Searching around old forum posts and the likes lead me to this spell: [Might of Ragnaros](https://classic.wowhead.com/spell=21154/might-of-ragnaros) (which is also hidden)

From my understanding, Ragnaros will summon that invisible [Flame of Ragnaros](https://classic.wowhead.com/npc=13148/flame-of-ragnaros) on top of a player, and that monster casts [Intense Heat](https://classic.wowhead.com/spell=21155/intense-heat).

To aid this pull request, I just now searched Twitch for "Molten Core PUG" to find some less organized runs, and found the perfect demonstration. [This stream was from 3 days ago](https://clips.twitch.tv/PeacefulSparklyGarbageTheRinger). You can clearly see the range check in the middle of the screen, and that mage on his right is pretty far away - yet he still gets hit.

So, the spell does say 20 yards, but I think 18 is a better check than 23. It's a compromise, and when I've tested 18 myself, it seems to be good enough.