### PR TITLE
Attempt fix Frenzy warning bug from #440

### DIFF
--- a/DBM-BWL/Flamegor.lua
+++ b/DBM-BWL/Flamegor.lua
@@ -49,9 +49,9 @@ do
 	local Frenzy = DBM:GetSpellInfo(23342)
 	function mod:SPELL_CAST_SUCCESS(args)
 		--if args.spellId == 23342 then
-		if args.spellName == Frenzy and args:IsDestTypeHostile() then
+		if args.spellName == Frenzy and args:IsSrcTypeHostile() then
 			if self.Options.SpecWarn23342dispel then
-				specWarnFrenzy:Show(args.destName)
+				specWarnFrenzy:Show(args.sourceName)
 				specWarnFrenzy:Play("enrage")
 			else
 				warnFrenzy:Show()


### PR DESCRIPTION
Somehow a bug was introduced in 600111be9b496944c43e797b7f6950a517da0a12 that stopped Frenzy from showing up at all for **Flamegor**.
**Chromaggus** and **Magmadar** still work as expected and show the boss name.

Only reason I can think of would be that I changed the filter to check `IsDestTypeHostile` to be consistent with the other two.

I am unable to test the mod again until next reset, so this PR will just be changing it back to how it was, and use `args.sourceName` instead.