### PR TITLE
Kel chain

### DIFF
--- a/DBM-Naxx/FrostwyrmLair/Kel'Thuzad.lua
+++ b/DBM-Naxx/FrostwyrmLair/Kel'Thuzad.lua
@@ -139,9 +139,8 @@ do
 				--timerMCCD:Start(60)--60 seconds?
 			end
 			if self.Options.SetIconOnMC2 then
-				local destIndex = UnitInRaid(args.destName)
-				local _, _, group = GetRaidRosterInfo(destIndex)
-				if group == 1 or group == 3 or group == 5 or group == 7 then
+				local _, _, group = GetRaidRosterInfo(UnitInRaid(args.destName))
+				if group % 2 == 1 then
 					self:SetIcon(args.destName, self.vb.MCIcon1)
 					self.vb.MCIcon1 = self.vb.MCIcon1 + 1
 				else

--- a/DBM-Naxx/FrostwyrmLair/Kel'Thuzad.lua
+++ b/DBM-Naxx/FrostwyrmLair/Kel'Thuzad.lua
@@ -51,7 +51,6 @@ mod.vb.warnedAdds = false
 mod.vb.MCIcon1 = 1
 mod.vb.MCIcon2 = 5
 local frostBlastTargets = {}
-local chainsTargets = {}
 
 local function AnnounceBlastTargets(self)
 	if self.Options.SetIconOnFrostTomb2 then
@@ -134,23 +133,21 @@ do
 			end
 		--elseif args.spellId == 28410 then -- Chains of Kel'Thuzad
 		elseif args.spellName == ChainsofKT then
-			chainsTargets[#chainsTargets + 1] = args.destName
 			if self:AntiSpam() then
-				table.wipe(chainsTargets)
 				self.vb.MCIcon1 = 1
 				self.vb.MCIcon2 = 5
 				--timerMCCD:Start(60)--60 seconds?
 			end
 			if self.Options.SetIconOnMC2 then
-	                        local destIndex = UnitInRaid(args.destName)
-        	                local _,_,group = GetRaidRosterInfo(destIndex)
-                	        if group == 1 or group == 3 or group ==5 or group == 7 then
-                        	        self:SetIcon(args.destName, self.vb.MCIcon1)
-                                	self.vb.MCIcon1 = self.vb.MCIcon1 + 1
-	                        else
-        	                        self:SetIcon(args.destName, self.vb.MCIcon2)
-                	                self.vb.MCIcon2 = self.vb.MCIcon2 - 1
-                        	end
+				local destIndex = UnitInRaid(args.destName)
+				local _, _, group = GetRaidRosterInfo(destIndex)
+				if group == 1 or group == 3 or group == 5 or group == 7 then
+					self:SetIcon(args.destName, self.vb.MCIcon1)
+					self.vb.MCIcon1 = self.vb.MCIcon1 + 1
+				else
+					self:SetIcon(args.destName, self.vb.MCIcon2)
+					self.vb.MCIcon2 = self.vb.MCIcon2 - 1
+				end
 			end
 			warnChainsTargets:CombinedShow(1, args.destName)
 		end

--- a/DBM-Naxx/FrostwyrmLair/Kel'Thuzad.lua
+++ b/DBM-Naxx/FrostwyrmLair/Kel'Thuzad.lua
@@ -53,13 +53,6 @@ mod.vb.MCIcon2 = 5
 local frostBlastTargets = {}
 local chainsTargets = {}
 
-local function AnnounceChainsTargets(self)
-	warnChainsTargets:Show(table.concat(chainsTargets, "< >"))
-	table.wipe(chainsTargets)
-	self.vb.MCIcon1 = 1
-	self.vb.MCIcon2 = 5
-end
-
 local function AnnounceBlastTargets(self)
 	if self.Options.SetIconOnFrostTomb2 then
 		for i = #frostBlastTargets, 1, -1 do
@@ -143,6 +136,7 @@ do
 		elseif args.spellName == ChainsofKT then
 			chainsTargets[#chainsTargets + 1] = args.destName
 			if self:AntiSpam() then
+				table.wipe(chainsTargets)
 				self.vb.MCIcon1 = 1
 				self.vb.MCIcon2 = 5
 				--timerMCCD:Start(60)--60 seconds?

--- a/DBM-Naxx/FrostwyrmLair/Kel'Thuzad.lua
+++ b/DBM-Naxx/FrostwyrmLair/Kel'Thuzad.lua
@@ -41,15 +41,24 @@ local timerfrostBlast		= mod:NewBuffActiveTimer(4, 27808, nil, nil, nil, 5, nil,
 --local timerMCCD			= mod:NewCDTimer(90, 28410, nil, nil, nil, 3)--actually 60 second cdish but its easier to do it this way for the first one.
 local timerPhase2			= mod:NewTimer(330, "TimerPhase2", "136116", nil, nil, 6)
 
-mod:AddSetIconOption("SetIconOnMC2", 28410, false, false, {1, 2, 3})
+mod:AddSetIconOption("SetIconOnMC2", 28410, false, false, {1, 2, 3, 4, 5})
 mod:AddSetIconOption("SetIconOnManaBomb", 27819, false, false, {8})
 mod:AddSetIconOption("SetIconOnFrostTomb2", 27808, false, false, {1, 2, 3, 4, 5, 6, 7, 8})
 mod:AddRangeFrameOption(10, 27819)
 
 mod.vb.phase = 1
 mod.vb.warnedAdds = false
-mod.vb.MCIcon = 1
+mod.vb.MCIcon1 = 1
+mod.vb.MCIcon2 = 5
 local frostBlastTargets = {}
+local chainsTargets = {}
+
+local function AnnounceChainsTargets(self)
+	warnChainsTargets:Show(table.concat(chainsTargets, "< >"))
+	table.wipe(chainsTargets)
+	self.vb.MCIcon1 = 1
+	self.vb.MCIcon2 = 5
+end
 
 local function AnnounceBlastTargets(self)
 	if self.Options.SetIconOnFrostTomb2 then
@@ -71,9 +80,11 @@ end
 
 function mod:OnCombatStart(delay)
 	self.vb.phase = 1
+	table.wipe(chainsTargets)
 	table.wipe(frostBlastTargets)
 	self.vb.warnedAdds = false
-	self.vb.MCIcon = 1
+	self.vb.MCIcon1 = 1
+	self.vb.MCIcon2 = 5
 	specwarnP2Soon:Schedule(320-delay)
 	timerPhase2:Start()
 	warnPhase2:Schedule(330)
@@ -130,14 +141,23 @@ do
 			end
 		--elseif args.spellId == 28410 then -- Chains of Kel'Thuzad
 		elseif args.spellName == ChainsofKT then
+			chainsTargets[#chainsTargets + 1] = args.destName
 			if self:AntiSpam() then
-				self.vb.MCIcon = 1
+				self.vb.MCIcon1 = 1
+				self.vb.MCIcon2 = 5
 				--timerMCCD:Start(60)--60 seconds?
 			end
 			if self.Options.SetIconOnMC2 then
-				self:SetIcon(args.destName, self.vb.MCIcon)
+	                        local destIndex = UnitInRaid(args.destName)
+        	                local _,_,group = GetRaidRosterInfo(destIndex)
+                	        if group == 1 or group == 3 or group ==5 or group == 7 then
+                        	        self:SetIcon(args.destName, self.vb.MCIcon1)
+                                	self.vb.MCIcon1 = self.vb.MCIcon1 + 1
+	                        else
+        	                        self:SetIcon(args.destName, self.vb.MCIcon2)
+                	                self.vb.MCIcon2 = self.vb.MCIcon2 - 1
+                        	end
 			end
-			self.vb.MCIcon = self.vb.MCIcon + 1
 			warnChainsTargets:CombinedShow(1, args.destName)
 		end
 	end

--- a/DBM-Naxx/FrostwyrmLair/Kel'Thuzad.lua
+++ b/DBM-Naxx/FrostwyrmLair/Kel'Thuzad.lua
@@ -72,7 +72,6 @@ end
 
 function mod:OnCombatStart(delay)
 	self.vb.phase = 1
-	table.wipe(chainsTargets)
 	table.wipe(frostBlastTargets)
 	self.vb.warnedAdds = false
 	self.vb.MCIcon1 = 1


### PR DESCRIPTION
Modifcation on Chain of Kel'Thuzad:

1. Chain of KT use the first 5 icons instead of 3;
2. Mark mind controlled players in odd groups in the order from 1 (star) to 5 (moon), while those in even groups from 5 (moon) to 1 (star). This will make it more easy for mages to select target closer to them.