### PR TITLE
AQ40: Turn off default for C'Thun beam raid icon

### DIFF
--- a/DBM-AQ40/CThun.lua
+++ b/DBM-AQ40/CThun.lua
@@ -40,7 +40,7 @@ local timerGiantClawTentacle	= mod:NewTimer(60, "TimerGiantClawTentacle", 26391,
 local timerWeakened				= mod:NewTimer(45, "TimerWeakened", 28598)
 
 mod:AddRangeFrameOption("10")
-mod:AddSetIconOption("SetIconOnEyeBeam", 26134, true, false, {1})
+mod:AddSetIconOption("SetIconOnEyeBeam", 26134, false, false, {1})
 mod:AddInfoFrameOption(nil, true)
 
 mod.vb.phase = 1

--- a/DBM-AQ40/CThun.lua
+++ b/DBM-AQ40/CThun.lua
@@ -40,7 +40,7 @@ local timerGiantClawTentacle	= mod:NewTimer(60, "TimerGiantClawTentacle", 26391,
 local timerWeakened				= mod:NewTimer(45, "TimerWeakened", 28598)
 
 mod:AddRangeFrameOption("10")
-mod:AddSetIconOption("SetIconOnEyeBeam", 26134, false, false, {1})
+mod:AddSetIconOption("SetIconOnEyeBeam2", 26134, false, false, {1})
 mod:AddInfoFrameOption(nil, true)
 
 mod.vb.phase = 1
@@ -135,7 +135,7 @@ do
 	local EyeBeam = DBM:GetSpellInfo(26134)
 	function mod:EyeBeamTarget(targetname, uId)
 		if not targetname then return end
-		if self.Options.SetIconOnEyeBeam then
+		if self.Options.SetIconOnEyeBeam2 then
 			self:SetIcon(targetname, 1, 3)
 		end
 		if targetname == UnitName("player") then


### PR DESCRIPTION
This change is to have DBM follow current Classic meta in regards to default boss settings.

Melee heavy comps are commonplace and often raid marks are used to designate group positions around C'Thun, which leads to confusion if raid marks are moved.

This is something I've seen and heard from raid leaders pretty much since AQ40 release, but I felt like it was finally time to change the default when I recently saw a raid assistant being shouted at for not having turned off the option.