### PR TITLE
Start the UpdateBar index at 0 rather than 1 to fix incorrect offset.

### DIFF
--- a/DBM-StatusBarTimers/DBT.lua
+++ b/DBM-StatusBarTimers/DBT.lua
@@ -607,11 +607,11 @@ function DBT:UpdateBars(sortBars)
 	end
 	for i, bar in ipairs(largeBars) do
 		bar.frame:ClearAllPoints()
-		bar.frame:SetPoint("TOP", largeBarsAnchor, "TOP", i * self.Options.HugeBarXOffset, (i * (self.Options.Height + self.Options.HugeBarYOffset)) * (self.Options.ExpandUpwardsLarge and 1 or -1))
+		bar.frame:SetPoint("TOP", largeBarsAnchor, "TOP", (i - 1) * self.Options.HugeBarXOffset, ((i - 1) * (self.Options.Height + self.Options.HugeBarYOffset)) * (self.Options.ExpandUpwardsLarge and 1 or -1))
 	end
 	for i, bar in ipairs(smallBars) do
 		bar.frame:ClearAllPoints()
-		bar.frame:SetPoint("TOP", smallBarsAnchor, "TOP", i * self.Options.BarXOffset, (i * (self.Options.Height + self.Options.BarYOffset)) * (self.Options.ExpandUpwards and 1 or -1))
+		bar.frame:SetPoint("TOP", smallBarsAnchor, "TOP", (i - 1) * self.Options.BarXOffset, ((i - 1) * (self.Options.Height + self.Options.BarYOffset)) * (self.Options.ExpandUpwards and 1 or -1))
 	end
 end
 


### PR DESCRIPTION
I noticed a bug that prevented me from moving my timer bars to the very top of my screen. I could get them close, but not all the way to the top. After digging around in the code I found that `Options.TimerY` point was being correctly set to 0, but the `DBT:UpdateBars` was adding additional bar's worth of offset before displaying the first bar. I made a change to start the iterator's index at 0 instead of 1. Moving the bars top the very top of the screen now works as expected.